### PR TITLE
[Change] Initialize mono_dpkg_options with Ansible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Available variables are listed below, along with default values:
     mono_disable_plugin: []
     mono_disablerepo: []
     mono_dist: "{{ ansible_distribution|lower }}"
-    mono_dpkg_options: []
+    mono_dpkg_options: 
+     - force-confdef
+     - force-confold
     mono_enable_plugin: []
     mono_enablerepo: []
     mono_packages: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 mono_disable_plugin: []
 mono_disablerepo: []
 mono_dist: "{{ ansible_distribution|lower }}"
-mono_dpkg_options: []
+mono_dpkg_options: 
+ - force-confdef
+ - force-confold
 mono_enable_plugin: []
 mono_enablerepo: []
 mono_packages: []


### PR DESCRIPTION
Ansible apt module has dpkg_options set to "force-confdef,force-confold"
https://docs.ansible.com/ansible/latest/modules/apt_module.html

Mono installation should use the same defaults.